### PR TITLE
chore: add auth support to firebase setup

### DIFF
--- a/src/lib/firebase.js
+++ b/src/lib/firebase.js
@@ -1,12 +1,13 @@
 import { initializeApp } from 'firebase/app'
 import { getAnalytics } from 'firebase/analytics'
 import { getFirestore } from 'firebase/firestore'
+import { getAuth, GoogleAuthProvider } from 'firebase/auth'
 
 const firebaseConfig = {
   apiKey: 'AIzaSyB_2y3bQTIGqZ4H6UXewigrOhkRwgTCEwE',
   authDomain: 'commarilia-4b2fe.firebaseapp.com',
   projectId: 'commarilia-4b2fe',
-  storageBucket: 'commarilia-4b2fe.firebasestorage.app',
+  storageBucket: 'commarilia-4b2fe.appspot.com',
   messagingSenderId: '830914787082',
   appId: '1:830914787082:web:cfdc83f14c10c11c2a6cf3',
   measurementId: 'G-H5G9MR0CR4'
@@ -20,4 +21,6 @@ if (typeof window !== 'undefined') {
 }
 
 export const db = getFirestore(app)
+export const auth = getAuth(app)
+export const provider = new GoogleAuthProvider()
 export { analytics }


### PR DESCRIPTION
## Summary
- export Firebase auth and Google provider along with existing Firestore and analytics setup
- correct storage bucket value in Firebase config

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689d6af60a0483268c717a15b896b74d